### PR TITLE
User multiple tenant

### DIFF
--- a/lib/HomePage.dart
+++ b/lib/HomePage.dart
@@ -14,11 +14,12 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   Unleash unl;
+  String tenantSelected;
+  String flagText;
 
   @override
   Widget build(BuildContext context) {
     initConfigs();
-    String flagText;
 
     return Scaffold(
       appBar: AppBar(
@@ -35,6 +36,45 @@ class _HomePageState extends State<HomePage> {
                 child: Text(
                   'Consulta de flags!!',
                   style: TextStyle(color: Colors.black, fontSize: 35),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(15),
+              child:  Container(
+                height: 50,
+                width: 500,
+                decoration: BoxDecoration(
+                    border: Border.all(color: Colors.grey),
+                    borderRadius: BorderRadius.all(Radius.circular(5))
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: ButtonTheme(
+                    alignedDropdown: true,
+                    child: DropdownButton<String>(
+                      value: tenantSelected,
+                      iconEnabledColor:Colors.black,
+                      items: widget.tenantsOfUser.map<DropdownMenuItem<String>>((value) {
+                        return DropdownMenuItem<String>(
+                          value: value,
+                          child: Text(
+                              value,
+                              style: TextStyle(fontSize: 16)
+                          ),
+                        );
+                      }).toList(),
+                      hint:Text(
+                        "Escolha um tenant",
+                        style: TextStyle(
+                            color: Colors.black,
+                            fontSize: 16,
+                        ),
+                      ),
+                      onChanged: (value) {
+                        setState(() => tenantSelected = value);
+                      },
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/HomePage.dart
+++ b/lib/HomePage.dart
@@ -4,6 +4,10 @@ import 'package:flutter_dotenv/flutter_dotenv.dart' as DotEnv;
 import 'package:unleash/unleash.dart';
 
 class HomePage extends StatefulWidget {
+  const HomePage({this.tenantsOfUser});
+
+  final List<String> tenantsOfUser;
+
   @override
   _HomePageState createState() => _HomePageState();
 }

--- a/lib/login_controller.dart
+++ b/lib/login_controller.dart
@@ -40,4 +40,14 @@ class LoginController {
 
     return listaLogins.contains(_login);
   }
+
+  List<String> getTenantsOfUser() {
+    List<String> allTenantsOfUser = [];
+    for (final tenant in (_usuarios['acesso'] as Map).keys) {
+      if (_usuarios['acesso'][tenant].contains(_login)) {
+        allTenantsOfUser.add(tenant);
+      }
+    }
+    return allTenantsOfUser;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,9 @@ class _LoginPageState extends State<LoginPage> {
                 onPressed: () {
                   if (_loginController.validaLogin()) {
                     Navigator.push(
-                        context, MaterialPageRoute(builder: (_) => HomePage()));
+                        context, MaterialPageRoute(builder: (_) =>
+                          HomePage(tenantsOfUser: _loginController.getTenantsOfUser()))
+                    );
                   } else {
                     print("Usuario não cadastrado");
                   }


### PR DESCRIPTION
Attacking #4 

As mentioned in #4 , it would be great if we could choose a specific tenant of a newly logged user. 

This pr is a initial step to achieve this goal.

data string used (change it in `acessos()` of `login_controller.dart`): 

`{"acesso": {"pewter": ["dev1","dev2","dev3"],"goldenrod": ["dev1","dev2","dev6"],"cerulean": ["dev7","dev2","dev9"]}}`

![selectTenant](https://user-images.githubusercontent.com/31549095/207369169-e37e5905-4c87-4a14-813d-e712bc521dda.gif)
