### PR TITLE
Latest unleash

### DIFF
--- a/lib/HomePage.dart
+++ b/lib/HomePage.dart
@@ -74,6 +74,7 @@ class _HomePageState extends State<HomePage> {
         appName: '<appname>',
         instanceId: '${DotEnv.dotenv.env['INSTANCE_ID']}',
         unleashApi: Uri.parse('${DotEnv.dotenv.env['URL_API']}'),
+        apiToken: 'not used by gitlab'
       ),
     );
   }

--- a/lib/HomePage.dart
+++ b/lib/HomePage.dart
@@ -9,12 +9,12 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  Unleash unl;
+  late Unleash unl;
 
   @override
   Widget build(BuildContext context) {
     initConfigs();
-    String flagText;
+    String flagText = '';
 
     return Scaffold(
       appBar: AppBar(
@@ -67,13 +67,13 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> initConfigs() async {
-    await DotEnv.load();
+    await DotEnv.dotenv.load();
 
     unl = await Unleash.init(
       UnleashSettings(
         appName: '<appname>',
-        instanceId: '${DotEnv.env['INSTANCE_ID']}',
-        unleashApi: Uri.parse('${DotEnv.env['URL_API']}'),
+        instanceId: '${DotEnv.dotenv.env['INSTANCE_ID']}',
+        unleashApi: Uri.parse('${DotEnv.dotenv.env['URL_API']}'),
       ),
     );
   }

--- a/lib/login_controller.dart
+++ b/lib/login_controller.dart
@@ -6,8 +6,8 @@ import 'package:path_provider/path_provider.dart';
 class LoginController {
 
   var _usuarios;
-  String _tenant;
-  String _login;
+  String? _tenant;
+  String? _login;
 
   Future<void> acessos() async {
     Directory directory = await getApplicationDocumentsDirectory();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,7 +253,7 @@ packages:
       name: unleash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.4.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,70 +7,70 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -82,7 +82,7 @@ packages:
       name: flutter_dotenv
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "5.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -94,105 +94,105 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "4.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.28"
+    version: "2.0.10"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "2.1.6"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+8"
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.4"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.9.2"
+    version: "2.0.6"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.1.3"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.2.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -204,77 +204,77 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   unleash:
     dependency: "direct main"
     description:
       name: unleash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.4+1"
+    version: "2.3.6"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.0+3"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,17 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  path_provider: ^1.6.28
-  cupertino_icons: ^0.1.3
-  flutter_dotenv: ^3.1.0
-  unleash: ^0.1.2
+  path_provider: ^2.0.0
+  cupertino_icons: ^1.0.1
+  flutter_dotenv: ^5.0.0
+  unleash: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path_provider: ^2.0.0
   cupertino_icons: ^1.0.1
   flutter_dotenv: ^5.0.0
-  unleash: ^0.2.0
+  unleash: ^0.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
depends on #16 

TLDR update Unleash to make your lives easier.

Didn't find any exemples of using `Context` aside from https://github.com/Unleash/unleash_proxy_client_flutter/blob/main/test/unleash_proxy_client_flutter_test.dart. which are in the latest version of unleash. I had problems with the API of Context in version 0.2.0.

Variable  `UNLEASH_API_TOKEN` isn't used by Gitlab https://docs.gitlab.com/ee/operations/feature_flags.html#unleash-proxy-example   

![image](https://user-images.githubusercontent.com/38257122/222531321-9dac4244-5593-4395-8f8d-1dfb6eb153c9.png)
